### PR TITLE
ci: automate bug fixes and feature builds via Claude Code on issue events

### DIFF
--- a/.github/workflows/claude-issue-handler.yml
+++ b/.github/workflows/claude-issue-handler.yml
@@ -1,0 +1,40 @@
+name: Claude Issue Handler
+
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  fix-bug:
+    if: contains(github.event.issue.labels.*.name, 'bug')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Claude config
+        run: git clone https://github.com/stevenmburns/dot-claude-files ~/.claude
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: "/fix-issue ${{ github.event.issue.number }}"
+          allowed_tools: "Bash,Glob,Grep,Read,Write,Edit"
+
+  build-feature:
+    if: contains(github.event.issue.labels.*.name, 'enhancement')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Claude config
+        run: git clone https://github.com/stevenmburns/dot-claude-files ~/.claude
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: "/build-issue ${{ github.event.issue.number }}"
+          allowed_tools: "Bash,Glob,Grep,Read,Write,Edit"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that triggers when issues are opened or labeled
- `fix-bug` job runs `/fix-issue <number>` via Claude Code when a `bug` label is present
- `build-feature` job runs `/build-issue <number>` via Claude Code when an `enhancement` label is present
- Clones `dot-claude-files` at runtime so project skills are available in CI

## Test plan
- [ ] Add `ANTHROPIC_API_KEY` secret to repo (Settings → Secrets and variables → Actions)
- [ ] Open or label an issue with `bug` and verify the `fix-bug` job triggers
- [ ] Open or label an issue with `enhancement` and verify the `build-feature` job triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)