### PR TITLE
Binary GCD variant using bitmask to eliminate final rescale shift

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,6 +1,6 @@
 import math
 import timeit
-from gcd import gcd, gcd_subtraction, gcd_modulo
+from gcd import gcd, gcd_subtraction, gcd_modulo, gcd_binary_unscaled
 
 CASES = [
     (12, 8),
@@ -13,6 +13,7 @@ IMPLEMENTATIONS = [
     ("subtraction", gcd_subtraction),
     ("binary    ", gcd),
     ("modulo    ", gcd_modulo),
+    ("binary_us ", gcd_binary_unscaled),
     ("math.gcd  ", math.gcd),
 ]
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -27,5 +27,7 @@ for a, b in CASES:
         t = timeit.timeit(lambda: fn(a, b), number=REPEATS) / REPEATS
         unit = "s" if t >= 0.001 else "µs"
         display = t if t >= 0.001 else t * 1_000_000
-        print(f"gcd({a}, {b}){'':<{20 - len(str(a)) - len(str(b))}} {label}   {display:>10.3f} {unit}")
+        print(
+            f"gcd({a}, {b}){'':<{20 - len(str(a)) - len(str(b))}} {label}   {display:>10.3f} {unit}"
+        )
     print()

--- a/conftest.py
+++ b/conftest.py
@@ -2,13 +2,24 @@ import pytest
 
 
 def pytest_addoption(parser):
-    parser.addoption("--slow", action="store_true", default=False, help="run slow tests")
-    parser.addoption("--hypothesis", action="store_true", default=False, help="run property-based hypothesis tests")
+    parser.addoption(
+        "--slow", action="store_true", default=False, help="run slow tests"
+    )
+    parser.addoption(
+        "--hypothesis",
+        action="store_true",
+        default=False,
+        help="run property-based hypothesis tests",
+    )
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')")
-    config.addinivalue_line("markers", "hypothesis: marks property-based tests (excluded from CI)")
+    config.addinivalue_line(
+        "markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')"
+    )
+    config.addinivalue_line(
+        "markers", "hypothesis: marks property-based tests (excluded from CI)"
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/conftest.py
+++ b/conftest.py
@@ -3,10 +3,12 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption("--slow", action="store_true", default=False, help="run slow tests")
+    parser.addoption("--hypothesis", action="store_true", default=False, help="run property-based hypothesis tests")
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')")
+    config.addinivalue_line("markers", "hypothesis: marks property-based tests (excluded from CI)")
 
 
 def pytest_collection_modifyitems(config, items):
@@ -14,4 +16,10 @@ def pytest_collection_modifyitems(config, items):
         skip = pytest.mark.skip(reason="use --slow to run")
         for item in items:
             if "slow" in item.keywords:
+                item.add_marker(skip)
+
+    if not config.getoption("--hypothesis", default=False):
+        skip = pytest.mark.skip(reason="use --hypothesis to run")
+        for item in items:
+            if "hypothesis" in item.keywords:
                 item.add_marker(skip)

--- a/gcd.py
+++ b/gcd.py
@@ -52,3 +52,34 @@ def gcd(a: int, b: int) -> int:
             break
 
     return a << k
+
+
+def gcd_binary_unscaled(a: int, b: int) -> int:
+    # Variant of Knuth Algorithm B — starting point for removing the final << k
+    if a == 0:
+        return b
+    if b == 0:
+        return a
+
+    k = 0
+    while (a | b) & 1 == 0:
+        a >>= 1
+        b >>= 1
+        k += 1
+
+    t = -b if (a & 1) else a
+
+    while True:
+        while t & 1 == 0:
+            t >>= 1
+
+        if t > 0:
+            a = t
+        else:
+            b = -t
+
+        t = a - b
+        if t == 0:
+            break
+
+    return a << k

--- a/gcd.py
+++ b/gcd.py
@@ -68,17 +68,14 @@ def gcd_binary_unscaled(a: int, b: int) -> int:
 
     t = -b if (a & m) else a
 
-    while True:
-        while not (t & m):
-            t >>= 1
-
-        if t > 0:
-            a = t
+    while t:
+        if t & m:
+            if t > 0:
+                a = t
+            else:
+                b = -t
+            t = a - b
         else:
-            b = -t
-
-        t = a - b
-        if t == 0:
-            break
+            t >>= 1
 
     return a

--- a/gcd.py
+++ b/gcd.py
@@ -55,22 +55,21 @@ def gcd(a: int, b: int) -> int:
 
 
 def gcd_binary_unscaled(a: int, b: int) -> int:
-    # Variant of Knuth Algorithm B — starting point for removing the final << k
+    # Variant of Knuth Algorithm B using a bitmask instead of shifting a/b.
+    # m = 2^k is the lowest bit shared by both a and b; used as the unit of
+    # "oddness" throughout so the final << k rescale is not needed.
     if a == 0:
         return b
     if b == 0:
         return a
 
-    k = 0
-    while (a | b) & 1 == 0:
-        a >>= 1
-        b >>= 1
-        k += 1
+    s = a | b
+    m = s & -s  # isolate lowest shared power of 2
 
-    t = -b if (a & 1) else a
+    t = -b if (a & m) else a
 
     while True:
-        while t & 1 == 0:
+        while not (t & m):
             t >>= 1
 
         if t > 0:
@@ -82,4 +81,4 @@ def gcd_binary_unscaled(a: int, b: int) -> int:
         if t == 0:
             break
 
-    return a << k
+    return a

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+hypothesis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 hypothesis
+ruff

--- a/test_gcd.py
+++ b/test_gcd.py
@@ -1,6 +1,8 @@
 import math
 import time
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from gcd import gcd, gcd_subtraction, gcd_modulo, gcd_binary_unscaled
 
 
@@ -31,6 +33,30 @@ def test_gcd_modulo(a, b, expected):
 @pytest.mark.parametrize("a,b,expected", cases)
 def test_gcd_binary_unscaled(a, b, expected):
     assert gcd_binary_unscaled(a, b) == expected
+    assert gcd_binary_unscaled(a, b) == math.gcd(a, b)
+
+
+nonneg = st.integers(min_value=0, max_value=10_000_000)
+
+
+@pytest.mark.hypothesis
+@given(a=nonneg, b=nonneg)
+@settings(max_examples=500)
+def test_property_gcd_matches_math(a, b):
+    assert gcd(a, b) == math.gcd(a, b)
+
+
+@pytest.mark.hypothesis
+@given(a=nonneg, b=nonneg)
+@settings(max_examples=500)
+def test_property_gcd_modulo_matches_math(a, b):
+    assert gcd_modulo(a, b) == math.gcd(a, b)
+
+
+@pytest.mark.hypothesis
+@given(a=nonneg, b=nonneg)
+@settings(max_examples=500)
+def test_property_gcd_binary_unscaled_matches_math(a, b):
     assert gcd_binary_unscaled(a, b) == math.gcd(a, b)
 
 

--- a/test_gcd.py
+++ b/test_gcd.py
@@ -13,7 +13,7 @@ cases = [
     (0, 5, 5),
     (7, 7, 7),
     (48, 18, 6),
-    (16, 24, 8),   # gcd is a pure power of 2 (k=3)
+    (16, 24, 8),  # gcd is a pure power of 2 (k=3)
     (24, 36, 12),  # gcd has a power-of-2 factor: 12 = 4 * 3 (k=2)
 ]
 
@@ -83,4 +83,6 @@ def test_subtraction_slow_case():
     elapsed = time.perf_counter() - start
 
     assert result == 1
-    assert elapsed > 5, f"expected ~10s, got {elapsed:.1f}s — algorithm may have changed"
+    assert elapsed > 5, (
+        f"expected ~10s, got {elapsed:.1f}s — algorithm may have changed"
+    )

--- a/test_gcd.py
+++ b/test_gcd.py
@@ -1,7 +1,7 @@
 import math
 import time
 import pytest
-from gcd import gcd, gcd_subtraction, gcd_modulo
+from gcd import gcd, gcd_subtraction, gcd_modulo, gcd_binary_unscaled
 
 
 cases = [
@@ -24,6 +24,12 @@ def test_gcd_matches_math(a, b, expected):
 def test_gcd_modulo(a, b, expected):
     assert gcd_modulo(a, b) == expected
     assert gcd_modulo(a, b) == math.gcd(a, b)
+
+
+@pytest.mark.parametrize("a,b,expected", cases)
+def test_gcd_binary_unscaled(a, b, expected):
+    assert gcd_binary_unscaled(a, b) == expected
+    assert gcd_binary_unscaled(a, b) == math.gcd(a, b)
 
 
 @pytest.mark.slow

--- a/test_gcd.py
+++ b/test_gcd.py
@@ -11,6 +11,8 @@ cases = [
     (0, 5, 5),
     (7, 7, 7),
     (48, 18, 6),
+    (16, 24, 8),   # gcd is a pure power of 2 (k=3)
+    (24, 36, 12),  # gcd has a power-of-2 factor: 12 = 4 * 3 (k=2)
 ]
 
 


### PR DESCRIPTION
## Summary
- Add \`gcd_binary_unscaled\`: a variant of Knuth Algorithm B that uses a bitmask \`m = (a|b) & -(a|b)\` instead of stripping common factors of 2 from \`a\` and \`b\`, eliminating the final \`<< k\` rescale step
- Restructure the algorithm into a single \`while t\` loop — when \`t & m\`, perform the GCD reduction step; otherwise shift \`t\` right one bit
- Add parametrised test cases with common powers of 2 (\`(16,24,8)\` and \`(24,36,12)\`) that specifically exercise the new masking logic
- Add Hypothesis property tests (500 examples each) comparing all implementations against \`math.gcd\`; gated behind \`--hypothesis\` flag and excluded from CI

## Test plan
- [ ] `pytest -v -m "not slow"` — all 24 parametrised tests pass
- [ ] `pytest --hypothesis -m "not slow"` — 500-example property tests pass for all implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)